### PR TITLE
fix(config): write generated config as JSON to prevent YAML date corruption

### DIFF
--- a/src/em-commons.ts
+++ b/src/em-commons.ts
@@ -27,7 +27,7 @@ try {
     generateServerlessConfig()
 
     result = runCommand(
-      'npx cross-env AWS_SDK_LOAD_CONFIG=1 NODE_OPTIONS=--max_old_space_size=4096 npx serverless deploy --config generated.serverless.yml',
+      'npx cross-env AWS_SDK_LOAD_CONFIG=1 NODE_OPTIONS=--max_old_space_size=4096 npx serverless deploy --config generated.serverless.json',
       scriptArgs
     )
   }
@@ -36,7 +36,7 @@ try {
     generateServerlessConfig()
 
     result = runCommand(
-      'npx cross-env AWS_SDK_LOAD_CONFIG=1 NODE_OPTIONS=--max_old_space_size=4096 npx serverless dev --config generated.serverless.yml',
+      'npx cross-env AWS_SDK_LOAD_CONFIG=1 NODE_OPTIONS=--max_old_space_size=4096 npx serverless dev --config generated.serverless.json',
       scriptArgs
     )
   }
@@ -45,7 +45,7 @@ try {
     generateServerlessConfig()
 
     result = runCommand(
-      'npx cross-env DISABLE_EPSAGON=TRUE NODE_OPTIONS=--max_old_space_size=4096 npx serverless invoke local --config generated.serverless.yml',
+      'npx cross-env DISABLE_EPSAGON=TRUE NODE_OPTIONS=--max_old_space_size=4096 npx serverless invoke local --config generated.serverless.json',
       scriptArgs
     )
   }
@@ -65,7 +65,7 @@ try {
     generateServerlessConfig()
 
     result = runCommand(
-      'npx cross-env NODE_OPTIONS=--max_old_space_size=4096 npx serverless --config generated.serverless.yml',
+      'npx cross-env NODE_OPTIONS=--max_old_space_size=4096 npx serverless --config generated.serverless.json',
       scriptArgs
     )
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,12 +17,12 @@ export const generateServerlessConfig = () => {
 
   const generatedConfig = mergeWith(commonConfig, serviceConfig, mergeCustomizer)
 
-  fs.writeFileSync('./generated.serverless.yml', YAML.stringify(generatedConfig))
+  fs.writeFileSync('./generated.serverless.json', JSON.stringify(generatedConfig, null, 2))
 }
 
 export const cleanup = () => {
-  if (fs.existsSync('./generated.serverless.yml')) {
-    fs.unlinkSync('./generated.serverless.yml')
+  if (fs.existsSync('./generated.serverless.json')) {
+    fs.unlinkSync('./generated.serverless.json')
   }
 }
 


### PR DESCRIPTION
## Summary
- Write `generated.serverless.json` instead of `generated.serverless.yml`
- `YAML.stringify` strips quotes from date-like strings (e.g. `"2012-10-17"` → `2012-10-17`), which `js-yaml` (Serverless Framework) then parses as Date objects, breaking IAM policy `Version` fields
- `JSON.stringify` preserves string types correctly and SLS natively supports `--config *.json`

## Test plan
- [x] Deploy any service that uses `em-commons deploy` and verify it works
- [x] Verify services with custom IAM roles containing `Version: "2012-10-17"` deploy without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)