### PR TITLE
fix(utils): use shell mode in runCommand to support quoted args

### DIFF
--- a/src/em-commons.ts
+++ b/src/em-commons.ts
@@ -56,7 +56,7 @@ try {
 
   if (script === 'jest') {
     result = runCommand(
-      'npx cross-env NODE_OPTIONS=--max_old_space_size=4096 jest -w 4 --ci --forceExit --config node_modules/@emarketeer/ts-microservice-commons/dist/lib/jest.config.js',
+      'npx cross-env NODE_OPTIONS="--max_old_space_size=4096 --experimental-vm-modules" jest -w 4 --ci --forceExit --config node_modules/@emarketeer/ts-microservice-commons/dist/lib/jest.config.js',
       scriptArgs
     )
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,13 +26,15 @@ export const cleanup = () => {
   }
 }
 
+const escapeShellArg = (arg: string): string => {
+  return "'" + arg.replace(/'/g, "'\\''") + "'"
+}
+
 export const runCommand = (command: string, additionalArgs: string[] = []) => {
-  const commandParts = command.split(' ')
+  const escapedArgs = additionalArgs.map(escapeShellArg).join(' ')
+  const fullCommand = additionalArgs.length > 0 ? command + ' ' + escapedArgs : command
 
-  const program = commandParts[0]
-  const args = commandParts.slice(1).concat(additionalArgs)
+  console.log('running ', fullCommand)
 
-  console.log('running ', program, args.join(' '))
-
-  return spawn.sync(program, args, { stdio: 'inherit' })
+  return spawn.sync(fullCommand, [], { stdio: 'inherit', shell: true })
 }


### PR DESCRIPTION
## Summary

- `runCommand` was splitting command strings by spaces and passing parts as separate args to `spawn.sync`. Quotes became literal characters, so `NODE_OPTIONS="--flag1 --flag2"` was split into `NODE_OPTIONS="--flag1` and `--flag2"`.
- Pass the full command string with `shell: true` so the shell handles quoting properly.

## Test plan

- [x] Verified the jest command in `em-commons.ts` with `NODE_OPTIONS="--max_old_space_size=4096 --experimental-vm-modules"` is parsed correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)