### PR TITLE
fix(cdk): clear deprecated pointInTimeRecovery and subnet warnings

### DIFF
--- a/src/cdk/constructs/dynamodb.ts
+++ b/src/cdk/constructs/dynamodb.ts
@@ -36,7 +36,9 @@ export class EmDynamoDBTable extends Construct {
       partitionKey: config.partitionKey,
       sortKey: config.sortKey,
       billingMode: config.billingMode || BillingMode.PAY_PER_REQUEST,
-      pointInTimeRecovery: config.pointInTimeRecovery ?? config.stage === 'prod',
+      pointInTimeRecoverySpecification: {
+        pointInTimeRecoveryEnabled: config.pointInTimeRecovery ?? config.stage === 'prod'
+      },
       deletionProtection: config.deletionProtection ?? config.stage === 'prod',
       stream: config.stream ? StreamViewType.NEW_AND_OLD_IMAGES : undefined,
       timeToLiveAttribute: config.timeToLiveAttribute,

--- a/src/cdk/utils/rds-vpc.ts
+++ b/src/cdk/utils/rds-vpc.ts
@@ -1,4 +1,5 @@
 import { Construct } from 'constructs'
+import { Annotations } from 'aws-cdk-lib'
 import * as ec2 from 'aws-cdk-lib/aws-ec2'
 import { Role, ManagedPolicy } from 'aws-cdk-lib/aws-iam'
 import { Stage, VpcConfig } from '../types'
@@ -35,9 +36,17 @@ export function createRdsVpcConfig(
     vpcId: config.vpcId
   })
 
-  const privateSubnets = config.privateSubnetIds.map((subnetId, index) =>
-    ec2.Subnet.fromSubnetId(scope, `RdsPrivateSubnet${index}-${stage}`, subnetId)
-  )
+  // Lambdas placed in these subnets need a route to RDS, but never read
+  // `subnet.routeTable.routeTableId`. Acknowledge the CDK warning that
+  // `fromSubnetId` emits for imports without route-table info.
+  const privateSubnets = config.privateSubnetIds.map((subnetId, index) => {
+    const subnet = ec2.Subnet.fromSubnetId(scope, `RdsPrivateSubnet${index}-${stage}`, subnetId)
+    Annotations.of(subnet).acknowledgeWarning(
+      '@aws-cdk/aws-ec2:noSubnetRouteTableId',
+      'Lambda-to-RDS networking does not consult subnet route tables.'
+    )
+    return subnet
+  })
 
   const lambdaSecurityGroup = new ec2.SecurityGroup(scope, `RdsLambdaSecurityGroup-${stage}`, {
     vpc,

--- a/src/cdk/utils/rds-vpc.ts
+++ b/src/cdk/utils/rds-vpc.ts
@@ -36,14 +36,14 @@ export function createRdsVpcConfig(
     vpcId: config.vpcId
   })
 
-  // Lambdas placed in these subnets need a route to RDS, but never read
-  // `subnet.routeTable.routeTableId`. Acknowledge the CDK warning that
-  // `fromSubnetId` emits for imports without route-table info.
+  // The imported subnets are only handed to Lambda's VpcConfig. We never read
+  // `subnet.routeTable.routeTableId`, so acknowledge the CDK warning that
+  // `fromSubnetId` emits for imports without route-table metadata.
   const privateSubnets = config.privateSubnetIds.map((subnetId, index) => {
     const subnet = ec2.Subnet.fromSubnetId(scope, `RdsPrivateSubnet${index}-${stage}`, subnetId)
     Annotations.of(subnet).acknowledgeWarning(
       '@aws-cdk/aws-ec2:noSubnetRouteTableId',
-      'Lambda-to-RDS networking does not consult subnet route tables.'
+      'This construct only passes imported subnets to Lambda VpcConfig and does not require routeTableId metadata.'
     )
     return subnet
   })


### PR DESCRIPTION
## Summary

Two CDK synth-time warnings that affect every consumer of `EmDynamoDBTable` and `createRdsVpcConfig`:

1. **`pointInTimeRecovery` is deprecated** in `aws-cdk-lib.aws_dynamodb.TableOptions` and scheduled for removal in the next major. The construct now uses `pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: ... }`. The synthed CloudFormation is unchanged — existing assertions on `PointInTimeRecoverySpecification: { PointInTimeRecoveryEnabled: ... }` still pass.
2. **`@aws-cdk/aws-ec2:noSubnetRouteTableId`** fires once per private subnet imported by `createRdsVpcConfig`, because `Subnet.fromSubnetId` constructs the subnet without route-table metadata. The Lambda→RDS path doesn't read `subnet.routeTable.routeTableId`, so the warning was noise. Acknowledged via `Annotations.of(subnet).acknowledgeWarning(...)` with a reason string, which is CDK's sanctioned way to document intent and silence the warning for all consumers.

Downstream: after this lands and is released, `billing-service` synth goes from ~7 warnings to 0 without any consumer-side changes.

## Test plan

- [x] `yarn test:cdk` — all 202 tests pass (including the existing PITR assertions, which already use the new CloudFormation property name)
- [x] `yarn build` — rollup build succeeds
- [x] Consumer smoke test: `billing-service` `yarn synth:cdk` with this package linked shows no warnings for PITR or subnet route tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)