### PR TITLE
DV-4292 Add opt-in ESM-friendly mode to em-commons jest

### DIFF
--- a/src/em-commons.ts
+++ b/src/em-commons.ts
@@ -76,8 +76,9 @@ if (script === 'cdk-lint') {
 }
 
 if (script === 'jest') {
-  // --experimental-vm-modules is required for AWS SDK v3's credential-provider chain
-  // (uses dynamic import() internally, which Jest intercepts and needs this flag for).
+  // --experimental-vm-modules is required so Jest can execute ES-module files
+  // in its VM — used by AWS SDK v3's dynamic credential-provider imports and
+  // by @mikro-orm/* (and other ESM-only packages) under EM_JEST_ESM_FRIENDLY=true.
   result = runCommand(
     'npx cross-env NODE_OPTIONS="--max_old_space_size=4096 --experimental-vm-modules" jest -w 4 --ci --forceExit --config node_modules/@emarketeer/ts-microservice-commons/dist/lib/jest.config.js',
     scriptArgs

--- a/src/em-commons.ts
+++ b/src/em-commons.ts
@@ -76,6 +76,8 @@ if (script === 'cdk-lint') {
 }
 
 if (script === 'jest') {
+  // --experimental-vm-modules is required for AWS SDK v3's credential-provider chain
+  // (uses dynamic import() internally, which Jest intercepts and needs this flag for).
   result = runCommand(
     'npx cross-env NODE_OPTIONS="--max_old_space_size=4096 --experimental-vm-modules" jest -w 4 --ci --forceExit --config node_modules/@emarketeer/ts-microservice-commons/dist/lib/jest.config.js',
     scriptArgs

--- a/src/jest.config.ts
+++ b/src/jest.config.ts
@@ -1,5 +1,22 @@
 const esModules = ['@eMarketeerSE/runtime-commons'].join('|')
 
+// Opt-in mode for services that depend on ESM-only packages (e.g. MikroORM v7).
+// When EM_JEST_ESM_FRIENDLY=true:
+//  - ts-jest compiles .ts as ESM (useESM), targeting es2022.
+//  - extensionsToTreatAsEsm lets Jest load .ts through its ESM VM loader,
+//    the same realm that handles ESM node_modules like @mikro-orm/*.
+// Opting-in services must import { jest } from '@jest/globals' in test files
+// that use jest.* APIs, since the `jest` global is CJS-only.
+const esmFriendly = process.env.EM_JEST_ESM_FRIENDLY === 'true'
+const tsJestTsConfig: Record<string, string> = {
+  target: esmFriendly ? 'es2022' : 'es6'
+}
+if (esmFriendly) {
+  // useESM needs an ES module output from TS; otherwise ts-jest still emits
+  // `exports.foo = ...` which explodes when Jest loads the file as ESM.
+  tsJestTsConfig.module = 'esnext'
+}
+
 const config: any = {
   verbose: true,
   testEnvironment: 'node',
@@ -7,10 +24,9 @@ const config: any = {
     '^.+\\.tsx?$': [
       'ts-jest',
       {
-        tsconfig: {
-          target: 'es6'
-        },
-        isolatedModules: true
+        tsconfig: tsJestTsConfig,
+        isolatedModules: true,
+        useESM: esmFriendly
       }
     ]
   },
@@ -20,6 +36,10 @@ const config: any = {
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   transformIgnorePatterns: [`/node_modules/(?!${esModules})`]
+}
+
+if (esmFriendly) {
+  config.extensionsToTreatAsEsm = ['.ts']
 }
 
 const shouldAddSetup = !process.argv.includes('unit')

--- a/src/jest.config.ts
+++ b/src/jest.config.ts
@@ -1,13 +1,21 @@
 const esModules = ['@eMarketeerSE/runtime-commons'].join('|')
 
-// Opt-in mode for services that depend on ESM-only packages (e.g. MikroORM v7).
+// Opt-in mode for services that depend on ESM-only packages (e.g. MikroORM).
 // When EM_JEST_ESM_FRIENDLY=true:
 //  - ts-jest compiles .ts as ESM (useESM), targeting es2022.
 //  - extensionsToTreatAsEsm lets Jest load .ts through its ESM VM loader,
 //    the same realm that handles ESM node_modules like @mikro-orm/*.
 // Opting-in services must import { jest } from '@jest/globals' in test files
 // that use jest.* APIs, since the `jest` global is CJS-only.
-const esmFriendly = process.env.EM_JEST_ESM_FRIENDLY === 'true'
+const rawEsmFriendly = process.env.EM_JEST_ESM_FRIENDLY
+const esmFriendly = rawEsmFriendly?.trim().toLowerCase() === 'true'
+if (rawEsmFriendly !== undefined && !esmFriendly) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[em-commons] EM_JEST_ESM_FRIENDLY=${JSON.stringify(rawEsmFriendly)} ignored;`
+    + ' expected \'true\'. Falling back to default CJS Jest config.'
+  )
+}
 const tsJestTsConfig: Record<string, string> = {
   target: esmFriendly ? 'es2022' : 'es6'
 }

--- a/src/jest.config.ts
+++ b/src/jest.config.ts
@@ -47,7 +47,9 @@ const config: any = {
 }
 
 if (esmFriendly) {
-  config.extensionsToTreatAsEsm = ['.ts']
+  // Must match the set of TS extensions transformed above (^.+\.tsx?$), or Jest
+  // will load .tsx as CJS while ts-jest emits ESM for it and blow up at import.
+  config.extensionsToTreatAsEsm = ['.ts', '.tsx']
 }
 
 const shouldAddSetup = !process.argv.includes('unit')


### PR DESCRIPTION
## Summary
- New opt-in env gate `EM_JEST_ESM_FRIENDLY=true` for `em-commons jest`. When set, switches ts-jest into ESM emit (`target: es2022`, `module: esnext`, `useESM: true`) and adds `extensionsToTreatAsEsm: ['.ts']` so Jest loads .ts through its ESM VM loader — the same realm that handles ESM-only node_modules like `@mikro-orm/*`.
- Default path is byte-identical for non-opting services: CJS output, `target: es6`, `--experimental-vm-modules` still on.

## Why
billing-service (DV-4247 credit-system epic) needs repository functional tests that import MikroORM v7, which is pure ESM. Every prior interop attempt (ts-jest CJS transforming MikroORM, @swc/jest variants, full Jest ESM) failed against the shared harness. This opt-in gate unblocks MikroORM-importing func tests without affecting services that don't need it.

Verified locally via `yarn link` against billing-service: 19/19 func tests green (including a two-connection FOR UPDATE contention test); 54/54 unit tests still green on the default CJS path.

## Consumer opt-in (for reference)
Services that opt in must:
- Set `EM_JEST_ESM_FRIENDLY=true` on their `test:func` script (e.g. via `cross-env`).
- `import { jest } from '@jest/globals'` in test files that use `jest.*` APIs.
- Use default imports for CJS packages with named exports (e.g. `import _ from 'lodash'; const { map } = _`).

## Test plan
- [ ] Verify a non-opting service's `yarn test:unit` and `yarn test:func` still pass unchanged after installing this release.
- [ ] Publish and validate downstream in billing-service (full repository func test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)