### PR TITLE
fix: revert jest-esm-warmup setupFile — the preload path is racy by construction

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -106,26 +106,4 @@ export default [{
     shebang(),
     executable(),
   ],
-}, {
-  input: 'src/lib/jest-esm-warmup.ts',
-  external: ['@eMarketeerSE/runtime-commons'],
-  output: [
-    // .mjs so Node/Jest parse as ESM regardless of em-commons' CJS package
-    // scope — a .js file here would fail: em-commons' package.json has no
-    // "type": "module", so Node's nearest-package-scope rule treats .js as
-    // CJS and rejects `import` + top-level await.
-    { file: 'dist/lib/jest-esm-warmup.mjs', format: 'esm', sourcemap: true },
-  ],
-  plugins: [
-    typescript({
-      useTsconfigDeclarationDir: true,
-      tsconfigOverride: {
-        compilerOptions: {
-          target: 'ES2022',
-          module: 'esnext',
-        },
-      },
-    }),
-    sourceMaps(),
-  ],
 }]

--- a/src/jest.config.ts
+++ b/src/jest.config.ts
@@ -50,10 +50,15 @@ if (esmFriendly) {
   // Must match the set of TS extensions transformed above (^.+\.tsx?$), or Jest
   // will load .tsx as CJS while ts-jest emits ESM for it and blow up at import.
   config.extensionsToTreatAsEsm = ['.ts', '.tsx']
-  // Preload runtime-commons' MikroORM modules during the worker's stable
-  // module-load phase so lazy loaders short-circuit at test time — avoids
-  // Jest's ESM teardown invariant racing dynamic imports in MikroORM.
-  config.setupFiles = [require.resolve('./jest-esm-warmup.mjs')]
+  // Previously this block wired in a `setupFiles` entry that called
+  // `preloadMikroOrmModules` from runtime-commons. That preload goes through
+  // the same Function-constructor dynamic-import path runtime-commons uses
+  // for MikroORM and hits Jest's `importModuleDynamically` teardown
+  // invariant on ~60–90% of multi-file -w 4 runs — whether called from
+  // beforeAll or from a setupFile. Consumers that need a stable MikroORM
+  // init under Jest ESM should import from `@eMarketeerSE/runtime-commons/mikroorm-esm`
+  // (static ESM imports, routed via Jest's `loadEsmModule` which captures
+  // the VM context once per file).
 }
 
 const shouldAddSetup = !process.argv.includes('unit')

--- a/src/jest.config.ts
+++ b/src/jest.config.ts
@@ -50,14 +50,14 @@ if (esmFriendly) {
   // Must match the set of TS extensions transformed above (^.+\.tsx?$), or Jest
   // will load .tsx as CJS while ts-jest emits ESM for it and blow up at import.
   config.extensionsToTreatAsEsm = ['.ts', '.tsx']
-  // NOTE: a setupFiles-based preload is tempting here but unsafe. Calling
-  // runtime-commons' MikroORM loaders from a setup file still routes every
-  // `import()` through Jest's `importModuleDynamically` handler, which
-  // re-asserts the per-file VM context on each call. The Function-constructor
-  // closure inside runtime-commons' CJS helper is bound to the first test
-  // file's VM; a second file on the same worker hits "Test environment has
-  // been torn down" on multi-file parallel runs (whether fired from
-  // beforeAll or from a setup file).
+  // Do not preload runtime-commons' MikroORM loaders via `setupFiles`.
+  // That preload still goes through a dynamic `import()`, which Jest routes
+  // through its `importModuleDynamically` handler — the handler re-asserts
+  // the per-file VM context on every call. The Function-constructor closure
+  // inside runtime-commons' CJS helper is bound to the first test file's
+  // VM; a second file on the same worker hits "Test environment has been
+  // torn down" on multi-file parallel runs (whether fired from beforeAll
+  // or from a setup file).
   //
   // Consumers who need a stable MikroORM init under Jest ESM should import
   // the ESM-only subpath, which uses static imports routed through Jest's

--- a/src/jest.config.ts
+++ b/src/jest.config.ts
@@ -50,15 +50,21 @@ if (esmFriendly) {
   // Must match the set of TS extensions transformed above (^.+\.tsx?$), or Jest
   // will load .tsx as CJS while ts-jest emits ESM for it and blow up at import.
   config.extensionsToTreatAsEsm = ['.ts', '.tsx']
-  // Previously this block wired in a `setupFiles` entry that called
-  // `preloadMikroOrmModules` from runtime-commons. That preload goes through
-  // the same Function-constructor dynamic-import path runtime-commons uses
-  // for MikroORM and hits Jest's `importModuleDynamically` teardown
-  // invariant on ~60–90% of multi-file -w 4 runs — whether called from
-  // beforeAll or from a setupFile. Consumers that need a stable MikroORM
-  // init under Jest ESM should import from `@eMarketeerSE/runtime-commons/mikroorm-esm`
-  // (static ESM imports, routed via Jest's `loadEsmModule` which captures
-  // the VM context once per file).
+  // NOTE: a setupFiles-based preload is tempting here but unsafe. Calling
+  // runtime-commons' MikroORM loaders from a setup file still routes every
+  // `import()` through Jest's `importModuleDynamically` handler, which
+  // re-asserts the per-file VM context on each call. The Function-constructor
+  // closure inside runtime-commons' CJS helper is bound to the first test
+  // file's VM; a second file on the same worker hits "Test environment has
+  // been torn down" on multi-file parallel runs (whether fired from
+  // beforeAll or from a setup file).
+  //
+  // Consumers who need a stable MikroORM init under Jest ESM should import
+  // the ESM-only subpath, which uses static imports routed through Jest's
+  // per-file module-load path (`loadEsmModule`):
+  //
+  //   // src/db/orm-init.ts
+  //   import { getMikroOrmMySqlConnection } from '@eMarketeerSE/runtime-commons/mikroorm-esm'
 }
 
 const shouldAddSetup = !process.argv.includes('unit')

--- a/src/lib/jest-esm-warmup.ts
+++ b/src/lib/jest-esm-warmup.ts
@@ -1,9 +1,0 @@
-// Runs at worker module-load phase (before beforeAll) when
-// EM_JEST_ESM_FRIENDLY=true. Populates runtime-commons' internal
-// MikroORM / MySqlDriver closure variables so its lazy loader's
-// `if (!MikroORM)` short-circuits during test execution — the
-// dynamic import() never fires, so Jest's ESM teardown invariant
-// can't race it.
-import { preloadMikroOrmModules } from '@eMarketeerSE/runtime-commons'
-
-await preloadMikroOrmModules()

--- a/src/lib/runtime-commons.d.ts
+++ b/src/lib/runtime-commons.d.ts
@@ -1,6 +1,0 @@
-// Ambient shim: em-commons doesn't depend on @eMarketeerSE/runtime-commons.
-// Consuming services provide it at runtime; Rollup marks it external at build
-// time; this declaration lets TS type-check the warmup file in isolation.
-declare module '@eMarketeerSE/runtime-commons' {
-  export const preloadMikroOrmModules: () => Promise<void>
-}


### PR DESCRIPTION
## Problem

8.2.1 wired a \`setupFiles\` entry into the ESM-friendly Jest config (\`src/jest.config.ts\` + new \`src/lib/jest-esm-warmup.ts\`) that called \`preloadMikroOrmModules()\` from runtime-commons at worker module-load phase. Intent: populate runtime-commons' internal \`MikroORM\`/\`MySqlDriver\` guards so test-phase \`getMikroOrmConnection\` calls would short-circuit the lazy \`if (!MikroORM)\` branch.

**It doesn't close the race.** Empirical testing in billing-service (10+ loop runs against runtime-commons 3.5.0, 3.6.0, and a local module-scope equivalent):

| Setup | Func-test flake rate |
| --- | --- |
| em-commons 8.2.0 + runtime-commons 3.5.0 | ~60% (beforeAll) |
| em-commons 8.2.1 + runtime-commons 3.5.0 | **100% hard-fail** — \`SyntaxError: does not provide an export named 'preloadMikroOrmModules'\` |
| em-commons 8.2.1 + runtime-commons 3.6.0 | **~80%** (setupFile-phase) |
| em-commons 8.2.0 + runtime-commons 3.6.0 + local module-scope preload | ~90% (beforeAll) |

Root cause: the preload goes through the same Function-constructor'd \`import()\` runtime-commons uses for MikroORM (to dodge tsc's \`require()\` down-leveling). Every such \`import()\` is routed through Jest's \`importModuleDynamically\` handler (\`jest-runtime/build/index.js:1515-1525\`), which re-asserts the VM context on every call. Under \`-w 4\` with per-file VM isolation:

1. First test file that imports runtime-commons → Function-constructor closure captures that file's VM context.
2. Second test file on the same worker → reuses Node's cached runtime-commons module, but the closure still references file 1's VM (now torn down).
3. setupFile (or beforeAll) fires \`preloadMikroOrmModules()\` → triggers the stale closure → Jest's invariant throws.

8.2.1 didn't move the race — it just gave the race a second place to fire. In practice it made every ESM-friendly consumer **flakier** than 8.2.0, not less: if they're on runtime-commons < 3.6.0 the setupFile hard-fails at import-time; if they're on 3.6.0 they flake at the setup phase itself.

## Fix

Revert the 8.2.1 setupFile additions entirely:

- Delete \`src/lib/jest-esm-warmup.ts\` and \`src/lib/runtime-commons.d.ts\`.
- Remove the rollup bundle entry that compiled them to \`dist/lib/jest-esm-warmup.mjs\`.
- Strip the \`config.setupFiles = [require.resolve('./jest-esm-warmup.mjs')]\` line from \`src/jest.config.ts\`; replace it with a comment pointing consumers at the real fix.

The ESM-friendly mode itself stays (\`extensionsToTreatAsEsm\`, \`useESM\` ts-jest transform) — that part is orthogonal and works correctly.

## The real fix (coordinated PR)

Consumers that need a stable MikroORM init under Jest ESM should switch their import to \`@eMarketeerSE/runtime-commons/mikroorm-esm\`, a new ESM-only subpath shipped in **runtime-commons [PR #32](https://github.com/eMarketeerSE/emarketeer-runtime-commons/pull/32)**. That subpath uses **static** \`import { MikroORM } from '@mikro-orm/core'\` / \`import { MySqlDriver } from '@mikro-orm/mysql'\` — routed via Jest's \`loadEsmModule\` (VM context captured once per file, stable) and never through \`importModuleDynamically\`. billing-service \`feat/dv-4258-credit-service\` has been running the structurally-equivalent inline pattern at 10/10 stable across repeated loops.

## Release

\`fix:\` title → patch bump (8.2.2). Effectively restores 8.2.0 behaviour with a version increment so consumers can move off the broken 8.2.1.

## Build verification

- \`npm run build\` completes; \`dist/lib/jest.config.js\` no longer contains \`config.setupFiles = ...\`; \`dist/lib/jest-esm-warmup.mjs\` is no longer emitted.
- \`npm test\` passes (no behavioural test surface changed; ESM-friendly config remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)